### PR TITLE
Fix build when image generation finishes early

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,13 +86,12 @@ const plantuml = async (gatsbyNodeHelpers, pluginOptions = {}) => {
       readableToString(plantumlProcess.stdout),
       readableToString(plantumlProcess.stderr),
       diagramAsStream.pipe(plantumlProcess.stdin),
+      onExit(plantumlProcess),
     ])
 
     if (stderr.length) {
       throw new Error(stderr)
     }
-
-    await onExit(plantumlProcess)
 
     return stdout
   }


### PR DESCRIPTION
Closes #2

The root cause seems to be that onExit may miss the event when the subprocess is already closed. 