### PR TITLE
Support headless

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,7 @@ const plantuml = async (gatsbyNodeHelpers, pluginOptions = {}) => {
 
   const runplantuml = async diagramAsText => {
     const plantumlProcess = spawn(`java`, [
+      `-Djava.awt.headless=true`,
       `-jar`,
       configuration.plantumljar,
       `-Dfile.encoding=utf8`,


### PR DESCRIPTION
In my headless environment(WSL).
Executing Plantuml needs option.
SEE [I have a message complaining about X11 or headless!](https://plantuml.com/ja/faq)

```
 java -jar ./lib/plantuml-jar-mit-1.2019.9/plantuml.jar
Exception in thread "main" java.awt.AWTError: Can't connect to X11 window server using ':0.0' as the value of the DISPLAY variable.
```

And Test failed before the src change.
I think it's probably because jest's snapshot-test has a different execution environment ?.

If there is no problem. Please test and merge.